### PR TITLE
[Bugfix] More weird version filenames and other fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func locatePromoVersion(mcVersion string, latest bool) (error, string) {
 // the path to the downloaded file
 func download(mcVersion, promoVersion string) (error, string) {
 	combinedVer := fmt.Sprintf("%s-%s", mcVersion, promoVersion)
-	if ((mcVersion == "1.7.10") || ((mcVersion == "1.8.9") && (strings.HasSuffix(promoVersion, ".2318"))) {
+	if ((mcVersion == "1.7.10") || ((mcVersion == "1.8.9") && (strings.HasSuffix(promoVersion, ".2318")))) {
 		combinedVer = fmt.Sprintf("%s-%s-%s", mcVersion, promoVersion, mcVersion)
 	}
 	

--- a/main.go
+++ b/main.go
@@ -98,17 +98,17 @@ func locatePromoVersion(mcVersion string, latest bool) (error, string) {
 		return errors.Wrap(err, "failed to decode promotions response"), ""
 	}
 
-	flavor := "recommended"
-	if (latest || (mcVersion == "1.8.8")) {
-		flavor = "latest"
-	}
-
-	for ver, promo := range promotions.Promos {
-		if strings.HasSuffix(ver, fmt.Sprintf("%s-%s", flavor, mcVersion)) {
+	for _, flavor := range []string{"recommended", "latest"} {
+		if (latest && (flavor == "recommended")) {
 			continue
 		}
-		if strings.HasPrefix(ver, fmt.Sprintf("%s-%s", mcVersion, flavor)) {
-			return nil, promo
+		for ver, promo := range promotions.Promos {
+			if strings.HasSuffix(ver, fmt.Sprintf("%s-%s", flavor, mcVersion)) {
+				continue
+			}
+			if strings.HasPrefix(ver, fmt.Sprintf("%s-%s", mcVersion, flavor)) {
+				return nil, promo
+			}
 		}
 	}
 
@@ -119,8 +119,14 @@ func locatePromoVersion(mcVersion string, latest bool) (error, string) {
 // the path to the downloaded file
 func download(mcVersion, promoVersion string) (error, string) {
 	combinedVer := fmt.Sprintf("%s-%s", mcVersion, promoVersion)
-	if ((mcVersion == "1.7.10") || (mcVersion == "1.8.9")) {
+	if mcVersion == "1.7.10" {
 		combinedVer = fmt.Sprintf("%s-%s-%s", mcVersion, promoVersion, mcVersion)
+	}
+	
+	if mcVersion == "1.8.9" {
+		if strings.HasSuffix(promoVersion, ".2318") {
+			combinedVer = fmt.Sprintf("%s-%s-%s", mcVersion, promoVersion, mcVersion)
+		}
 	}
 
 	if mcVersion == "1.10" {

--- a/main.go
+++ b/main.go
@@ -119,16 +119,10 @@ func locatePromoVersion(mcVersion string, latest bool) (error, string) {
 // the path to the downloaded file
 func download(mcVersion, promoVersion string) (error, string) {
 	combinedVer := fmt.Sprintf("%s-%s", mcVersion, promoVersion)
-	if mcVersion == "1.7.10" {
+	if ((mcVersion == "1.7.10") || ((mcVersion == "1.8.9") && (strings.HasSuffix(promoVersion, ".2318"))) {
 		combinedVer = fmt.Sprintf("%s-%s-%s", mcVersion, promoVersion, mcVersion)
 	}
 	
-	if mcVersion == "1.8.9" {
-		if strings.HasSuffix(promoVersion, ".2318") {
-			combinedVer = fmt.Sprintf("%s-%s-%s", mcVersion, promoVersion, mcVersion)
-		}
-	}
-
 	if mcVersion == "1.10" {
 		combinedVer = fmt.Sprintf("%s-%s-%s", mcVersion, promoVersion, "1.10.0")
 	}

--- a/main.go
+++ b/main.go
@@ -99,11 +99,14 @@ func locatePromoVersion(mcVersion string, latest bool) (error, string) {
 	}
 
 	flavor := "recommended"
-	if latest {
+	if (latest || (mcVersion == "1.8.8")) {
 		flavor = "latest"
 	}
 
 	for ver, promo := range promotions.Promos {
+		if strings.HasSuffix(ver, fmt.Sprintf("%s-%s", flavor, mcVersion)) {
+			continue
+		}
 		if strings.HasPrefix(ver, fmt.Sprintf("%s-%s", mcVersion, flavor)) {
 			return nil, promo
 		}
@@ -116,8 +119,12 @@ func locatePromoVersion(mcVersion string, latest bool) (error, string) {
 // the path to the downloaded file
 func download(mcVersion, promoVersion string) (error, string) {
 	combinedVer := fmt.Sprintf("%s-%s", mcVersion, promoVersion)
-	if mcVersion == "1.7.10" {
+	if ((mcVersion == "1.7.10") || (mcVersion == "1.8.9")) {
 		combinedVer = fmt.Sprintf("%s-%s-%s", mcVersion, promoVersion, mcVersion)
+	}
+
+	if mcVersion == "1.10" {
+		combinedVer = fmt.Sprintf("%s-%s-%s", mcVersion, promoVersion, "1.10.0")
 	}
 
 	url := fmt.Sprintf(


### PR DESCRIPTION
I found some more Forge versions with the weird filename scheme. This change fixes those too.

I have accounted for 1.8.8 only having a latest flavor.

Also made the promo selector skip 2 promos that need to be removed from the promotions file but haven't (both are for 1.7.10, makes forge-downloader pick an older version...)

Tested and works as expected.

EDIT:
Restored the original flavor selector for loop and made it work with the latest flag.
Also changed weird version handling for 1.8.9, since only the last 3 builds of Forge for that version have the naming weirdness.